### PR TITLE
Onboarding Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Instructions can be found here: https://devcenter.heroku.com/articles/heroku-cli
 
 - [ ] I received and accepted Heroku application invite.
 - [ ] I can access Innocent Tech App Heroku dashboard.
-- [ ] I have Heroku CLI installed and ready to go locallys.
+- [ ] I have Heroku CLI installed and ready to go locally.
 
 #### Github
 - [ ] Local environment has been set up on your computer
@@ -266,7 +266,7 @@ or alternatively,
 Run ruby test_file_name.rb
 ```
 
-Reading Minitest Output
+### Reading Minitest Output
 Minitest runs the tests in a random order, and outputs a green dot for a successful test, a red E if there was an error while running the test, and a red F if the test assertion failed.
 
 *Check-in: Are you  looking forward to writing tests?*
@@ -274,7 +274,24 @@ Minitest runs the tests in a random order, and outputs a green dot for a success
 - [ ] Its too early to tell 
 - [ ] No, not really
 
-#### Deployment Steps 
+#### Deployment Steps (Commit your work)
+
+### Heroku Deployment
+If you have the Heroku CLI installed (double check you do!), then you will need to add a Heroku remote to your local repository. 
+The app is already created so enter the command in your Terminal: 
+
+```bash
+heroku git:remote -a example-app
+```
+
+Commit changes to 
+```bash
+git push heroku main
+```
+
+
+
+### Readme Deployment
 *Please* double check you can commit to this repo. Then, follow the deployment steps listed below. 
 When you create your feature branch, follow this naming format for your branch: learn-earn-onboarding/[yourname]
 *You only need commit your Readme file with the checklist. No other files are needed!* 
@@ -290,7 +307,6 @@ When you create your feature branch, follow this naming format for your branch: 
 - [ ] Front end 
 - [ ] Back end 
 - [ ] I'm open to either 
-
 
 *Final Check-in: How did local set up go?*
 

--- a/README.md
+++ b/README.md
@@ -51,9 +51,10 @@ If you're not familiar with Asana, you can find more information here: https://h
 We will push our changes for testing and production to Heroku. https://devcenter.heroku.com/
 For committing changes to Heroku, we recommend getting the Heroku CLI set up on your laptop. 
 Instructions can be found here: https://devcenter.heroku.com/articles/heroku-cli 
+
 - [ ] I received and accepted Heroku application invite.
 - [ ] I can access Innocent Tech App Heroku dashboard.
-
+- [ ] I have Heroku CLI installed and ready to go locallys.
 
 #### Github
 - [ ] Local environment has been set up on your computer

--- a/README.md
+++ b/README.md
@@ -1,24 +1,174 @@
 # README
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+### Project: Innocent Tech 
 
-Things you may want to cover:
 
-* Ruby version
+For this cohort, you will be working on the educator user of an application called 'Innocent Tech.'
+Innocent Tech is a full-stack application that works to eradicate racial bias in the classroom to better support students of color. 
 
-* System dependencies
 
-* Configuration
+### Requirements
 
-* Database creation
+Technical requirements for this project. See below for step-by-step first-time setup.
 
-* Database initialization
+Ruby, Bundler, Rails, PostgresQL, Node, Yarn[include latest versions needed]
 
-* How to run the test suite
 
-* Services (job queues, cache servers, search engines, etc.)
+### Environment Setup
+This setup assumes you are using [Homebrew](https://brew.sh/) on a Mac. 
+Other environment setups are WIP.
 
-* Deployment instructions
+Clone the repo:
 
-* ...
+```sh
+git clone = git@github.com:softwareforgood/innocent_tech_app.git
+```
+
+Alternately, if you don't already have an SSH key setup with Github:
+```sh
+git clone https://github.com/softwareforgood/innocent_tech_app.git
+```
+
+#### Ruby
+
+If you don't have a Ruby version manager, you'll want to install `rbenv`. If you
+already have `rbenv` or `rvm` installed, skip this step.
+
+To find out if you already have one of them installed, in a terminal run
+```sh
+which rbenv rvm
+```
+
+If you're using `zsh` and you get the following, install `rbenv`:
+```sh
+rbenv not found
+rvm not found
+```
+
+If you're using `bash` and there's no output at all, that means you don't have
+either version manager installed, and you should install `rbenv`.
+
+**DO NOT INSTALL BOTH RVM AND RBENV ON THE SAME MACHINE OR YOU WILL HAVE A VERY BAD TIME!**
+
+_Note: if you have `rvm` installed but would like to switch to `rbenv` (recommended),
+just run the following before installing `rbenv`:_
+```sh
+rvm implode
+```
+
+**Install `rbenv`** (see https://github.com/rbenv/rbenv for more info)
+```sh
+brew install rbenv
+```
+
+Both `rbenv` and `rvm` will automatically try to use the version specified in a
+local `.ruby-version` file if it exists. If the version specified in `.ruby-version`
+is not installed, simply run:
+```sh
+rbenv install
+```
+Or for RVM:
+```sh
+rvm install
+```
+
+#### PostgreSQL - if not using using docker
+See if you have PostgreSQL:
+
+```sh
+psql --version
+```
+
+If it's not installed, or the version isn't >=11.0, install and run it using Homebrew:
+
+```sh
+brew install postgresql@12
+brew services stop postgresql
+brew services start postgresql@12
+```
+
+Create a db user:
+
+```sh
+psql -c "[authentication info here]';"
+```
+
+#### Redis - if not using using docker
+
+You'll need `redis` in order for `sidekiq` to work.
+
+```sh
+brew install redis
+brew services start redis
+```
+
+#### Rails
+
+```sh
+gem install bundler -v 2.3.7
+bundle install # Make sure you're in the innocent_tech_app root directory
+```
+
+*If you get an error installing `pg` while running the `bundle install` command, it may be resolved
+by running `brew install postgresql`, even if you have already installed `postgresql@11` or another
+specific version of `postgresql`. Unlike when you installed `postgresql@11` above, you do not need
+to start the `postgresql` service for this to fix your `bundle install` error.*
+
+#### Javascript
+You will need Yarn `v1.22.x`, a Node version manager (if you don't already have one, `nvm` is recommended), and Node `v16.x`.
+
+```sh
+brew install nvm yarn
+nvm install && nvm use # This will install and use the version in the project's `.nvmrc` file
+```
+
+#### DB setup
+
+Setup DB:
+
+```sh
+# From project root:
+bin/rails db:setup # runs `rake db:create db:schema:load db:seed
+```
+
+#### TailwindCSS (CSS Framework)
+ The CSS Framework we will be using for this project is called TailwindCSS.
+ More information on the framework can be found here: https://tailwindcss.com/
+ We recommend reading up on the documentation, syntax some before beginning the first sprint. 
+
+#### MiniTest / How To Run Tests 
+
+To run the tests:
+
+Open up a terminal
+Navigate to the directory
+Run ruby test_file_name.rb
+
+Reading Minitest Output
+Minitest runs the tests in a random order, and outputs a green dot for a successful test, a red E if there was an error while running the test, and a red F if the test assertion failed.
+
+
+#### Deployment Steps 
+Note: This is what we (Chelsey & Edith) will need to show that your local env is setup and you have completed onboarding.
+From main, create a new branch with the following naming format: learn-earn-onboarding/[yourname]
+Once thats created, edit the checklist on [file_name]
+
+Then, complete the next steps:
+
+  --commit your work on a feature branch
+  --make a PR to the main branch
+  --if PR approved, merge to main
+  --cd back to main
+  --pull the latest main branch
+
+
+#### Onboarding Checklist [Draft]
+
+- [ ] Repo cloned
+- [ ] All tools needed installed 
+- [ ] Create feature branch 
+- [ ] Accept Google Calendar invite for Apprenticeship program
+- [ ] Joined Slack channel -- posted on channel 
+- [ ] Joined Asana board -- assigned themselves a ticket 
+- [ ] Commit feature branch to repo
+- [ ] Create pull request for review -- sssign to edith + chelsey 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ At SFG and during the duration of this project, we will be using some technical 
 #### Figma
 We use Figma as our wireframe tool.
 The Innocent Tech wireframe can be accessed here: [link]
-For this wireframe, we are using SPRINT 6 as reference for front end changes. 
+NOTE: This is a very expansive wireframe. Feel free to explore more, but for this project, we will be using *SPRINT 6* as reference for front end changes. 
 - [ ] I received and accepted Figma wireframe invite.
 - [ ] I can access SPRINT 6 on the Figma wireframe.
 
@@ -70,6 +70,8 @@ The CSS Framework we will be using for this project is called TailwindCSS.
 More information on the framework can be found here: https://tailwindcss.com/
 We recommend reading up on the documentation, and syntax some before beginning the first sprint. 
 Setting up your local environment should install Tailwind for this application.
+
+
 
 ### Environment Setup
 This setup assumes you are using [Homebrew](https://brew.sh/) on a Mac. 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Instructions can be found here: https://devcenter.heroku.com/articles/heroku-cli
 
 
 #### TailwindCSS 
-The CSS Framework we will be using for this project is called TailwindCSS.
+The CSS Framework we will be using for this project is called TailwindCSS. We're using the library through the tailwindcss-rails gem.
 More information on the framework can be found here: https://tailwindcss.com/
 We recommend reading up on the documentation, and syntax some before beginning the first sprint. 
 Setting up your local environment should install Tailwind for this application.
@@ -235,7 +235,7 @@ rails s
 ```ruby
 rails c
 ```
-*Check-in: Can you start your rails console? *
+*Check-in: Can you start your rails console?*
 - [ ] No, something is up
 - [ ] Yes! Console started with not issue.
 
@@ -245,7 +245,7 @@ rails c
 rails rubocop
 ```
 
-*Check-in: Can you start your Rails linter? *
+*Check-in: Can you start your Rails linter?*
 - [ ] Yes! Rubocop ready!
 - [ ] No, I need Chelsey, Edith, or one of my team mates to help me
 
@@ -277,13 +277,14 @@ Minitest runs the tests in a random order, and outputs a green dot for a success
 #### Deployment Steps 
 *Please* double check you can commit to this repo. Then, follow the deployment steps listed below. 
 When you create your feature branch, follow this naming format for your branch: learn-earn-onboarding/[yourname]
-*You only commit your Readme file with the checklist. No other files are needed!* 
+*You only need commit your Readme file with the checklist. No other files are needed!* 
 
-  --commit your work on a feature branch
-  --make a PR to the main branch
-  --if PR approved, merge to main
-  --cd back to main
-  --pull the latest main branch
+  - [ ] Create a feature branch from main (follow this naming format: learn-earn-onboarding/[yourname])
+  - [ ] Edit your Readme
+  - [ ] Commit your feature branch to the repo
+  *Make sure you're only committing your readme*
+  - [ ] Open a Pull request. Change your PR title to: Yourname-Onboarding
+  - [ ] Request a review from Chelsey + Edith on your PR 
 
 *Check-in: Do you prefer Front-End development or Back-End development?*
 - [ ] Front end 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ There will be an Innocent Tech kick off the first week of the apprenticeship.
 For this apprenticeship, we will use development sprints to get the tasks completed. 
 Our sprints run for 2 weeks each, from Tuesday to the following Tuesday. 
 After each sprint, we will have a retro* every Wednesday after the sprint ends. 
-*A retro is [define retro]
+*We will cover retros more during the Welcome To SFG meeting. 
 - [ ] I received and accepted calendar invites for Sprint retros
 
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ More information on the framework can be found here: https://tailwindcss.com/
 We recommend reading up on the documentation, and syntax some before beginning the first sprint. 
 Setting up your local environment should install Tailwind for this application.
 
+  ### Compiling w/ TailwindCSS
+  To make sure you have the most up to date stylings, you will need to compile the code so Tailwind recognizes the new changes. 
+  To compile, run the command below in another Terminal window. 
+
+  ```sh
+    bin/rails tailwindcss:watch
+  ```
+  More commands on compiling w/ TailwindCSS rails gem can be found here: https://github.com/rails/tailwindcss-rails
+
 
 ### Environment Setup
 This setup assumes you are using [Homebrew](https://brew.sh/) on a Mac. 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ either version manager installed, and you should install `rbenv`.
 
 _Note: if you have `rvm` installed but would like to switch to `rbenv` (recommended),
 just run the following before installing `rbenv`:_
+
 ```sh
 rvm implode
 ```
@@ -64,6 +65,7 @@ brew install rbenv
 Both `rbenv` and `rvm` will automatically try to use the version specified in a
 local `.ruby-version` file if it exists. If the version specified in `.ruby-version`
 is not installed, simply run:
+
 ```sh
 rbenv install
 ```
@@ -72,7 +74,7 @@ Or for RVM:
 rvm install
 ```
 
-#### PostgreSQL - if not using using docker
+#### PostgreSQL
 See if you have PostgreSQL:
 
 ```sh
@@ -135,9 +137,11 @@ bin/rails db:setup # runs `rake db:create db:schema:load db:seed
  The CSS Framework we will be using for this project is called TailwindCSS.
  More information on the framework can be found here: https://tailwindcss.com/
  We recommend reading up on the documentation, syntax some before beginning the first sprint. 
+ Setting up your local environment should install Tailwind for this application.
 
 #### MiniTest / How To Run Tests 
 
+For this application, we are using the testing library Minitest. 
 To run the tests:
 
 Open up a terminal

--- a/README.md
+++ b/README.md
@@ -1,18 +1,75 @@
 # README
 
-### Project: Innocent Tech 
+Note: *Please* read this readme carefully. 
+*Onboarding instructions and tasks are listed throughout this readme.*
+The tasks shown throughout the readme are what we (Chelsey & Edith) will need to show that your local env is setup, you can commit to the repo, *and* you have completed onboarding.
+If you need assistance with *any* step of onboarding, please reach out to Chelsey + Edith through email or on Slack. 
 
+HAPPY CODING! 
+
+### Project: Innocent Tech 
 
 For this cohort, you will be working on the educator user of an application called 'Innocent Tech.'
 Innocent Tech is a full-stack application that works to eradicate racial bias in the classroom to better support students of color. 
+There will be an Innocent Tech kick off on [event info here]
+- [ ] I received and accepted the 'Innocent Tech Kickoff' invite
 
 
-### Requirements
+### Coding Practices 
+For this apprenticeship, we will use development sprints to get the tasks completed. 
+Our sprints run for 2 weeks each, from Tuesday to the following Tuesday. 
+We will have retros the Wednesday after the sprint ends. 
+- [ ] I received and accepted calendar invites for Sprint retros
 
-Technical requirements for this project. See below for step-by-step first-time setup.
 
-Ruby, Bundler, Rails, PostgresQL, Node, Yarn[include latest versions needed]
+### Technical Requirements + Tools Overview 
+At SFG and during the duration of this project, we will be using some technical requirements and tools that most of you are familiar with, and some new tools! Read on for the new additions. :) 
 
+#### Google Suite 
+- [ ] Received and Read the SFG Handbook
+- [ ] Accepted calendar invites for 'Welcome To SFG'
+- [ ] Accepted calendar invite for Apprentice calendar
+- [ ] Set your Google Calendar settings to everyone, so all SFG staff can access your calendar
+- [ ] Upload your timesheet document to your acct Google Docs, send link to Chelsey and Edith to access 
+
+#### Figma
+We use Figma as our wireframe tool.
+The Innocent Tech wireframe can be accessed here: [link]
+For this wireframe, we are using SPRINT 6 as reference for front end changes. 
+- [ ] I received and accepted Figma wireframe invite.
+- [ ] I can access SPRINT 6 on the Figma wireframe.
+
+
+### Asana 
+We will use Asana as our kan-ban board for this project. 
+If you're not familiar with Asana, you can find more information here: https://help.asana.com/hc/en-us/articles/14250783001627-How-to-start-using-Asana 
+- [ ] I received and accepted Asana board invite. 
+- [ ] I can access the Innocent Tech MVP Asana board. 
+
+
+#### Heroku 
+We will push our changes for testing and production to Heroku. https://devcenter.heroku.com/
+For committing changes to Heroku, we recommend getting the Heroku CLI set up on your laptop. 
+Instructions can be found here: https://devcenter.heroku.com/articles/heroku-cli 
+- [ ] I received and accepted Heroku application invite.
+- [ ] I can access Innocent Tech App Heroku dashboard.
+
+
+#### Github
+- [ ] Local environment has been set up on your computer
+- [ ] Created Onboarding pull request for review. 
+- [ ] Assigned your PR to Chelsey + Edith  
+
+#### Slack 
+- [ ] Accepted invite to Apprentice Slack channel, #sfg-team channel, sfg-watercooler channel, forecastplanning channel
+- [ ] Introduce yourself on the Apprentice Slack channel! Post a wave, hi, etc. to the Apprentice Slack channel. 
+
+
+#### TailwindCSS 
+The CSS Framework we will be using for this project is called TailwindCSS.
+More information on the framework can be found here: https://tailwindcss.com/
+We recommend reading up on the documentation, and syntax some before beginning the first sprint. 
+Setting up your local environment should install Tailwind for this application.
 
 ### Environment Setup
 This setup assumes you are using [Homebrew](https://brew.sh/) on a Mac. 
@@ -50,8 +107,13 @@ either version manager installed, and you should install `rbenv`.
 
 **DO NOT INSTALL BOTH RVM AND RBENV ON THE SAME MACHINE OR YOU WILL HAVE A VERY BAD TIME!**
 
+*Check-in: I DO NOT have RVM and RBENV installed.* 
+- [ ] Not at all! 
+- [ ] Let me double check.... 
+
 _Note: if you have `rvm` installed but would like to switch to `rbenv` (recommended),
 just run the following before installing `rbenv`:_
+
 
 ```sh
 rvm implode
@@ -95,7 +157,7 @@ Create a db user:
 psql -c "[authentication info here]';"
 ```
 
-#### Redis - if not using using docker
+#### Redis - if not using using docker 
 
 You'll need `redis` in order for `sidekiq` to work.
 
@@ -133,11 +195,9 @@ Setup DB:
 bin/rails db:setup # runs `rake db:create db:schema:load db:seed
 ```
 
-#### TailwindCSS (CSS Framework)
- The CSS Framework we will be using for this project is called TailwindCSS.
- More information on the framework can be found here: https://tailwindcss.com/
- We recommend reading up on the documentation, syntax some before beginning the first sprint. 
- Setting up your local environment should install Tailwind for this application.
+*Check-in:Verify your db is ready to go*
+- [ ] CHECK W/ EDITH ON HOW BEST TO DO THIS  
+
 
 #### MiniTest / How To Run Tests 
 
@@ -151,13 +211,15 @@ Run ruby test_file_name.rb
 Reading Minitest Output
 Minitest runs the tests in a random order, and outputs a green dot for a successful test, a red E if there was an error while running the test, and a red F if the test assertion failed.
 
+*Check-in: Are you  looking forward to writing tests?*
+- [ ] Yes, of course!
+- [ ] Its too early to tell 
+- [ ] No, not really
 
 #### Deployment Steps 
-Note: This is what we (Chelsey & Edith) will need to show that your local env is setup and you have completed onboarding.
-From main, create a new branch with the following naming format: learn-earn-onboarding/[yourname]
-Once thats created, edit the checklist on [file_name]
-
-Then, complete the next steps:
+*Please* double check you can commit to this repo. Then, follow the deployment steps listed below. 
+When you create your feature branch, follow this naming format for your branch: learn-earn-onboarding/[yourname]
+*You only commit your Readme file with the checklist. No other files are needed!* 
 
   --commit your work on a feature branch
   --make a PR to the main branch
@@ -165,14 +227,15 @@ Then, complete the next steps:
   --cd back to main
   --pull the latest main branch
 
+*Check-in: Do you prefer Front-End development or Back-End development?*
+- [ ] Front end 
+- [ ] Back end 
+- [ ] I'm open to either 
 
-#### Onboarding Checklist [Draft]
 
-- [ ] Repo cloned
-- [ ] All tools needed installed 
-- [ ] Create feature branch 
-- [ ] Accept Google Calendar invite for Apprenticeship program
-- [ ] Joined Slack channel -- posted on channel 
-- [ ] Joined Asana board -- assigned themselves a ticket 
-- [ ] Commit feature branch to repo
-- [ ] Create pull request for review -- sssign to edith + chelsey 
+*Final Check-in: How did local set up go?*
+
+- [ ] Double checked that *all* the onboarding tasks on this readme
+- [ ] I answered all of the check-in questions(including this one!) listed throughout this readme.
+- [ ] I'm ready to submit this readme for review! 
+

--- a/README.md
+++ b/README.md
@@ -3,27 +3,28 @@
 Note: *Please* read this readme carefully. 
 *Onboarding instructions and tasks are listed throughout this readme.*
 The tasks shown throughout the readme are what we (Chelsey & Edith) will need to show that your local env is setup, you can commit to the repo, *and* you have completed onboarding.
-If you need assistance with *any* step of onboarding, please reach out to Chelsey + Edith through email or on Slack. 
+If you need assistance with *any* step of onboarding, please reach out to Chelsey, Edith, or your team mates on Slack.
 
-HAPPY CODING! 
+HAPPY CODING!  
 
 ### Project: Innocent Tech 
 
 For this cohort, you will be working on the educator user of an application called 'Innocent Tech.'
 Innocent Tech is a full-stack application that works to eradicate racial bias in the classroom to better support students of color. 
-There will be an Innocent Tech kick off on [event info here]
+There will be an Innocent Tech kick off the first week of the apprenticeship.
 - [ ] I received and accepted the 'Innocent Tech Kickoff' invite
 
 
 ### Coding Practices 
 For this apprenticeship, we will use development sprints to get the tasks completed. 
 Our sprints run for 2 weeks each, from Tuesday to the following Tuesday. 
-We will have retros the Wednesday after the sprint ends. 
+After each sprint, we will have a retro* every Wednesday after the sprint ends. 
+*A retro is [define retro]
 - [ ] I received and accepted calendar invites for Sprint retros
 
 
 ### Technical Requirements + Tools Overview 
-At SFG and during the duration of this project, we will be using some technical requirements and tools that most of you are familiar with, and some new tools! Read on for the new additions. :) 
+At SFG and during the duration of this project, we will be using some technical requirements and tools that most of you are familiar with, and some new tools! Read on for the new additions. :D 
 
 #### Google Suite 
 - [ ] Received and Read the SFG Handbook
@@ -33,28 +34,32 @@ At SFG and during the duration of this project, we will be using some technical 
 - [ ] Upload your timesheet document to your acct Google Docs, send link to Chelsey and Edith to access 
 
 #### Figma
-We use Figma as our wireframe tool.
-The Innocent Tech wireframe can be accessed here: [link]
-NOTE: This is a very expansive wireframe. Feel free to explore more, but for this project, we will be using *SPRINT 6* as reference for front end changes. 
+We are using Figma as our wireframe tool.
+The Innocent Tech Figma invite will be sent to your sfg email address.(Please let us know if you do not!)
+NOTE: This is a very expansive wireframe. Feel free to explore more, but for this project, we will let you know which tabs of the wirefrsme to use for reference throughout the program.
 - [ ] I received and accepted Figma wireframe invite.
-- [ ] I can access SPRINT 6 on the Figma wireframe.
+- [ ] I can access ALL the tabs on the Figma wireframe.
 
 
 ### Asana 
 We will use Asana as our kan-ban board for this project. 
+The Innocent Tech Asana invite will be sent to your sfg email address.(Please let us know if you do not!)
 If you're not familiar with Asana, you can find more information here: https://help.asana.com/hc/en-us/articles/14250783001627-How-to-start-using-Asana 
 - [ ] I received and accepted Asana board invite. 
 - [ ] I can access the Innocent Tech MVP Asana board. 
 
 
 #### Heroku 
-We will push our changes for testing and production to Heroku. https://devcenter.heroku.com/
+We will push our changes for testing and production to Heroku. 
+The Innocent Tech Heroku invite will be sent to your sfg email address.(Please let us know if you do not!)
+You can find more Heroku dev information here: https://devcenter.heroku.com/
+
 For committing changes to Heroku, we recommend getting the Heroku CLI set up on your laptop. 
 Instructions can be found here: https://devcenter.heroku.com/articles/heroku-cli 
 
-- [ ] I received and accepted Heroku application invite.
-- [ ] I can access Innocent Tech App Heroku dashboard.
+- [ ] I received and accepted Innocent Tech App Heroku application invite.
 - [ ] I have Heroku CLI installed and ready to go locally.
+- [ ] I can access Innocent Tech App Heroku dashboard.
 
 #### Github
 - [ ] Local environment has been set up on your computer
@@ -62,15 +67,17 @@ Instructions can be found here: https://devcenter.heroku.com/articles/heroku-cli
 - [ ] Assigned your PR to Chelsey + Edith  
 
 #### Slack 
+One of our communication tools is Slack. You all are familiar with Slack since you all used it during your bootcamp. 
 - [ ] Accepted invite to Apprentice Slack channel, #sfg-team channel, sfg-watercooler channel, forecastplanning channel
-- [ ] Introduce yourself on the Apprentice Slack channel! Post a wave, hi, etc. to the Apprentice Slack channel. 
+Software For Good team is excited to have you working with us, and would love to lear more about you all! :D
+- [ ] Introduce yourself on the #sfg-team Slack channel! Share your name, post a wave, pronouns, and your preferrred/favorite programming tool(Vim,Visual Studio Code, etc.)  
 
 
 #### TailwindCSS 
-The CSS Framework we will be using for this project is called TailwindCSS. We're using the library through the tailwindcss-rails gem.
-More information on the framework can be found here: https://tailwindcss.com/
-We recommend reading up on the documentation, and syntax some before beginning the first sprint. 
-Setting up your local environment should install Tailwind for this application.
+The CSS Framework we will be using for this project is called [TailwindCSS](https://tailwindcss.com/).
+We're using TailwindCSS through the [tailwindcss-rails gem](https://github.com/rails/tailwindcss-rails). 
+We recommend reading up on the  gem documentation, and Tailwindcss syntax some before beginning the first sprint. 
+When you set up your local environment, Tailwind will be installed for the application. 
 
   ### Compiling w/ TailwindCSS
   To make sure you have the most up to date stylings, you will need to compile the code so Tailwind recognizes the new changes. 
@@ -79,7 +86,7 @@ Setting up your local environment should install Tailwind for this application.
   ```sh
     bin/rails tailwindcss:watch
   ```
-  More commands on compiling w/ TailwindCSS rails gem can be found here: https://github.com/rails/tailwindcss-rails
+  More compiling w/ TailwindCSS rails gem can be found here: https://github.com/rails/tailwindcss-rails
 
 
 ### Environment Setup
@@ -235,6 +242,13 @@ rails s
 ```ruby
 rails c
 ```
+
+#### Close out of Rails Console 
+```bash
+  cmd + c (mac)
+  ctrl + c (windows
+```
+
 *Check-in: Can you start your rails console?*
 - [ ] No, something is up
 - [ ] Yes! Console started with not issue.
@@ -251,7 +265,7 @@ rails rubocop
 
 #### MiniTest / How To Run Tests 
 
-For this application, we are using the testing library Minitest. 
+For this application, we are using the testing library [Minitest](https://github.com/minitest/minitest). 
 To run the tests:
 
 Open up a terminal
@@ -280,26 +294,27 @@ Minitest runs the tests in a random order, and outputs a green dot for a success
 If you have the Heroku CLI installed (double check you do!), then you will need to add a Heroku remote to your local repository. 
 The app is already created so enter the command in your Terminal: 
 
+Remote setup:
 ```bash
 heroku git:remote -a example-app
 ```
 
-Commit changes to 
+
+Commit changes: 
 ```bash
 git push heroku main
 ```
 
-
-
 ### Readme Deployment
-*Please* double check you can commit to this repo. Then, follow the deployment steps listed below. 
+Follow the deployment steps listed below. 
 When you create your feature branch, follow this naming format for your branch: learn-earn-onboarding/[yourname]
 *You only need commit your Readme file with the checklist. No other files are needed!* 
 
   - [ ] Create a feature branch from main (follow this naming format: learn-earn-onboarding/[yourname])
-  - [ ] Edit your Readme
+  - [ ] Edit your Readme(select answers to the checklist)
   - [ ] Commit your feature branch to the repo
   *Make sure you're only committing your readme*
+
   - [ ] Open a Pull request. Change your PR title to: Yourname-Onboarding
   - [ ] Request a review from Chelsey + Edith on your PR 
 
@@ -313,4 +328,3 @@ When you create your feature branch, follow this naming format for your branch: 
 - [ ] Double checked that *all* the onboarding tasks on this readme
 - [ ] I answered all of the check-in questions(including this one!) listed throughout this readme.
 - [ ] I'm ready to submit this readme for review! 
-


### PR DESCRIPTION
 I had an idea related to onboarding and readme’s: What if we use the readme as our dev onboarding document for the apprentices? 
It could be another async(flexible) way for all the apprentices to get ready for the program. 
As in, we leave steps(in the form of a checklist) for them to check off  on the readme, and submit to the repo for ‘review’. 
Small tasks on the different tools we use ( Github, Slack, Asana) that can show all of the apprentices have been introduced to these tools before the first sprint. 
