### PR TITLE
Removing the dark class from sidebar nav background

### DIFF
--- a/app/views/layouts/_sidebar_nav.html.erb
+++ b/app/views/layouts/_sidebar_nav.html.erb
@@ -1,6 +1,6 @@
 <!--Sidebar Navigation-->
 <aside id="separator-sidebar" class="fixed left-0 top-0 z-40 h-screen w-64 -translate-x-full transition-transform sm:translate-x-0" aria-label="Sidebar">
-  <div class="h-full overflow-y-auto bg-it-gray-50 px-3 py-4 dark:bg-gray-800">
+  <div class="h-full overflow-y-auto bg-gray-800 px-3 py-4">
     <ul class="space-y-2 font-medium">
       <li>
         <!--innocent_tech logo here-->


### PR DESCRIPTION
### Changes
Give a short summary of the changes made in this PR. 

Locally, the sidebar navigation appeared with a black background. 
The sidebar nav background had 2 classes: bg-gray-800, and dark:bg-gray-800. 
Using 'dark' in front of the background class made the sidebar nav appear in dark mode. 
This PR fixes the issue. 


### Link to Issue 
Link Asana ticket here!

### Comments, Notes, or  Questions
This section is if you want to share something related to the PR with the reviewer. 


### Related Screenshots 
For FE tickets specifcially, please include a screenshot of your work!


### Before you submit for review, Did you...

- [ ] Added relevant tests (if applicable)
- [ ] Linked Asana ticket to PR
- [ ] Added comments, notes, or questions for reviewwer
- [ ] Added relevant screenshots
- [ ] Ensured ticket title is clear and concise(i.e. 'Donation Form Feature' instead of 'sfg/chels/donation-form'
